### PR TITLE
fix: Preserve path-level OpenAPI parameters in addServiceInfo

### DIFF
--- a/src/Services/Swagger.php
+++ b/src/Services/Swagger.php
@@ -367,6 +367,10 @@ class Swagger extends BaseRestService
                     // Otherwise skip it to avoid treating it as an HTTP verb
                 }
             }
+            // Preserve path-level parameters (fix for path params like table_name)
+            if (isset($pathInfo['parameters'])) {
+                $paths[$path]['parameters'] = $pathInfo['parameters'];
+            }
         }
 
         $base['paths'] = array_merge((array)array_get($base, 'paths'), $paths);


### PR DESCRIPTION
The previous commit (c4de104) introduced a regression where path-level parameters (like table_name, id) were being skipped but not preserved in the output. This caused the Swagger UI to not display input fields for required path parameters.

The fix preserves path-level parameters after processing HTTP verbs.