### PR TITLE
Laravel 13.7 compatibility (Wave 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # df-apidoc
 API Documentation package containing OpenApi (aka Swagger) implementations for the DreamFactory(tm) services.
+
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,16 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
-    "dreamfactory/df-core": "~1.0"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {


### PR DESCRIPTION
## Summary

Upgrade `dreamfactory/df-apidoc` to Laravel 13.7. **Composer-only change** — no source patches required.

## Dependency matrix

```json
"require": {
    "php": "^8.3",
    "laravel/helpers": "^1.8",
    "dreamfactory/df-core": "~1.0.4"
},
"require-dev": {
    "laravel/framework": "^13.7",
    "mockery/mockery": "^1.6",
    "nunomaduro/collision": "^8.6",
    "phpunit/phpunit": "^11.5.3",
    "orchestra/testbench": "^11.0"
}
```

## Why no source changes were needed

Survey for the standard L13 invariant tripwires came back clean:

- No `Fruitcake\Cors\CorsService` references
- No `Illuminate\Foundation\Bus\DispatchesJobs` (removed in L11)
- No `setupBeforeClass` typos / `getDates` overrides / `prependMiddlewareToGroup` calls
- No `Connection`/`Builder`/`Grammar` extensions
- Only Illuminate API surface: `Illuminate\Support\ServiceProvider` (parent class, stable)
  and a docblock-only `Illuminate\Database\Query\Builder` hint in `Models/ServiceDoc.php`

The package consumes the legacy global helpers `array_get`, `camel_case`, and
`camelize` (via `Services/Swagger.php`); these are now polyfilled by
`laravel/helpers ^1.8` in production `require` so consumers don't need to add
the dep themselves.

## Test plan

Stage 1 — isolated install (path repos for df-core, df-system, df-database all on `shift/laravel-13`):
- [x] `composer validate --strict`: clean
- [x] `composer install`: 120 packages, L13.7.0 / PHPUnit 11.5.55 / orchestra/testbench 11.1.0 / df-core 1.0.99
- [x] `php -l` across all 5 source files: clean
- [x] `class_exists` smoke: 5/5 namespaced classes load + 4/4 helper polyfills (`array_get`, `camel_case`, `array_except`, `camelize`)

Stage 2 — host-app `shift-173254` with standard Wave-1+ strip-list (df-mongo-logs, df-git, df-oauth, df-mcp-server, plus other unmerged siblings) and `MongoDBServiceProvider` commented:
- [x] `composer install --no-dev`: 82 packages, df-apidoc mirrors cleanly from `/src/dreamfactory/df-apidoc`
- [x] Host-app autoload smoke: 5/5 classes resolve under L13.7.0 runtime

PHPUnit run not applicable in Stage 1: `tests/SwaggerServiceTest.php` extends `DreamFactory\Core\Testing\TestCase` which requires host-app `bootstrap/app.php` (same pattern as df-system, df-sqldb). Pre-existing test concerns (`assertAttributeEquals` and `assertArraySubset` were removed in PHPUnit 9+) are out of scope for this Laravel-only upgrade and exist on master today.

## Wave 3 dependencies

Depends on the following sibling PRs being merged first:
- df-core `shift/laravel-13`
- df-system `shift/laravel-13`
- df-user `shift/laravel-13`
- df-database `shift/laravel-13`